### PR TITLE
Improve canvas sizing mode, fix preview A/R

### DIFF
--- a/composeApp/src/commonMain/kotlin/des/c5inco/mesh/common/MeshGradient.kt
+++ b/composeApp/src/commonMain/kotlin/des/c5inco/mesh/common/MeshGradient.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.graphics.lerp
 @Composable
 fun Modifier.meshGradient(
     points: List<List<Pair<Offset, Color>>>,
-    blendMode: BlendMode = BlendMode.DstIn,
+    gradientBlendMode: BlendMode = BlendMode.DstIn,
     resolutionX: Int = 1,
     resolutionY: Int = 1,
     showPoints: Boolean = false,
@@ -33,6 +33,15 @@ fun Modifier.meshGradient(
     val pointData by remember(points, resolutionX, resolutionY) {
         derivedStateOf {
             PointData(points, resolutionX, resolutionY)
+        }
+    }
+
+    val pointsPaint = remember {
+        Paint().apply {
+            color = Color.White.copy(alpha = .9f)
+            strokeWidth = 3f
+            strokeCap = StrokeCap.Round
+            blendMode = BlendMode.SrcOver
         }
     }
 
@@ -52,29 +61,20 @@ fun Modifier.meshGradient(
                             colors = pointData.colors,
                             indices = indicesModifier(pointData.indices)
                         ),
-                        blendMode = blendMode,
+                        blendMode = gradientBlendMode,
                         paint = paint,
                     )
                 }
 
                 if (showPoints) {
-                    val flattenedPaint = Paint()
-                    flattenedPaint.color = Color.White.copy(alpha = .9f)
-                    flattenedPaint.strokeWidth = 4f * .001f
-                    flattenedPaint.strokeCap = StrokeCap.Round
-                    flattenedPaint.blendMode = BlendMode.SrcOver
+                    val intermediatePoints = pointData.offsets
+                        .map { Offset(it.x * size.width, it.y * size.height) }
 
-                    scale(
-                        scaleX = size.width,
-                        scaleY = size.height,
-                        pivot = Offset.Zero
-                    ) {
-                        canvas.drawPoints(
-                            pointMode = PointMode.Points,
-                            points = pointData.offsets,
-                            paint = flattenedPaint
-                        )
-                    }
+                    canvas.drawPoints(
+                        pointMode = PointMode.Points,
+                        points = intermediatePoints,
+                        paint = pointsPaint
+                    )
                 }
             }
         }

--- a/composeApp/src/desktopMain/kotlin/des/c5inco/mesh/App.kt
+++ b/composeApp/src/desktopMain/kotlin/des/c5inco/mesh/App.kt
@@ -31,12 +31,11 @@ fun App() {
         val coroutineScope = rememberCoroutineScope()
 
         GradientCanvas(
-            exportGraphicsLayer = exportGraphicsLayer,
-            exportScale = exportScale,
-            onPointDrag = { selectedColorPoint = it },
-            modifier = Modifier.weight(1f)
-        )
-        SidePanel(
+          exportGraphicsLayer = exportGraphicsLayer,
+          exportScale = exportScale,
+          modifier = Modifier.weight(1f)
+        ) { selectedColorPoint = it }
+      SidePanel(
             exportScale = exportScale,
             onExportScaleChange = { exportScale = it },
             onExport = {

--- a/composeApp/src/desktopMain/kotlin/des/c5inco/mesh/ui/components/ColorDropdown.kt
+++ b/composeApp/src/desktopMain/kotlin/des/c5inco/mesh/ui/components/ColorDropdown.kt
@@ -53,9 +53,9 @@ import org.jetbrains.jewel.ui.util.thenIf
 fun ColorDropdown(
     selectedColor: Int,
     colors: List<Color>,
+    modifier: Modifier = Modifier,
     allowTransparency: Boolean = false,
     onSelected: (Int) -> Unit,
-    modifier: Modifier = Modifier
 ) {
     val focusManager = LocalFocusManager.current
 

--- a/composeApp/src/desktopMain/kotlin/des/c5inco/mesh/ui/components/DimensionInputField.kt
+++ b/composeApp/src/desktopMain/kotlin/des/c5inco/mesh/ui/components/DimensionInputField.kt
@@ -24,9 +24,9 @@ fun DimensionInputField(
     max: Int? = null,
     enabled: Boolean = false,
     paramName: String,
-    onUpdate: (Int) -> Unit,
-    trailingIcon: @Composable (() -> Unit)? = null,
+    onValueChange: (Int) -> Unit,
     modifier: Modifier = Modifier,
+    trailingIcon: @Composable (() -> Unit)? = null,
 ) {
     val focusManager = LocalFocusManager.current
     val textFieldState = remember(value) { TextFieldState(value.toString()) }
@@ -57,7 +57,7 @@ fun DimensionInputField(
                         it
                     }
                 }
-                onUpdate(nextValue)
+                onValueChange(nextValue)
                 textFieldState.edit { replace(0, textFieldState.text.length, nextValue.toString()) }
             } ?: run {
                 reset()

--- a/composeApp/src/desktopMain/kotlin/des/c5inco/mesh/ui/data/AppState.kt
+++ b/composeApp/src/desktopMain/kotlin/des/c5inco/mesh/ui/data/AppState.kt
@@ -15,8 +15,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import java.awt.image.BufferedImage
 import java.io.File
@@ -66,8 +64,7 @@ object AppState {
     var constrainEdgePoints by mutableStateOf(true)
     val colors = defaultColors.toMutableStateList()
     var canvasBackgroundColor: Int by mutableStateOf(-1)
-    private val _canvasWidthMode = MutableStateFlow(DimensionMode.Fill)
-    val canvasWidthMode = _canvasWidthMode.asStateFlow()
+    var canvasSizeMode by mutableStateOf(DimensionMode.Fill)
 
     private val _notificationFlow = MutableSharedFlow<String>()
     val notificationFlow = _notificationFlow
@@ -75,25 +72,6 @@ object AppState {
     fun sendNotification(message: String) {
         scope.launch {
             _notificationFlow.emit(message)
-        }
-    }
-
-    fun updateCanvasWidthMode() {
-        _canvasWidthMode.value = if (_canvasWidthMode.value == DimensionMode.Fill) {
-            DimensionMode.Fixed
-        } else {
-            DimensionMode.Fill
-        }
-    }
-
-    private val _canvasHeightMode = MutableStateFlow(DimensionMode.Fill)
-    val canvasHeightMode = _canvasHeightMode.asStateFlow()
-
-    fun updateCanvasHeightMode() {
-        _canvasHeightMode.value = if (_canvasHeightMode.value == DimensionMode.Fill) {
-            DimensionMode.Fixed
-        } else {
-            DimensionMode.Fill
         }
     }
 


### PR DESCRIPTION
This commit changes the canvas sizing mode; it is now going to either fill available space, or have a fixed size, on both directions. This makes it behave more intuitively, and allows us to properly respect the canvas aspect ratio in the preview. This is reflected in the UI.

<img width="1178" alt="image" src="https://github.com/user-attachments/assets/886e7b07-5d7e-4fe2-bc2a-06d3e02ba614" />

That change also includes a bunch of cleanup (including addressing Lint complaints) of the project code.

It also includes a change to how points are drawn in the gradient, to avoid the points being squashed for non-square canvases.

Lastly, it adds an explicit output image size in the export scale selector, allowing a better understanding of what each option means.

https://github.com/user-attachments/assets/24662f7a-d6ce-4a86-bb3f-717a77216384
